### PR TITLE
Implemented a "local" CloudProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <type>bundle</type>
         </dependency>
         
         <!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
                     <release>11</release>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
+        <guava.version>29.0-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <mockito.version>3.3.3</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -43,6 +44,12 @@
     </distributionManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <type>bundle</type>
+        </dependency>
         
         <!-- Test -->
         <dependency>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,5 @@
 module org.cryptomator.cloudaccess {
 	exports org.cryptomator.cloudaccess.api;
+	
+	requires com.google.common;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module org.cryptomator.cloudaccess {
+	exports org.cryptomator.cloudaccess;
 	exports org.cryptomator.cloudaccess.api;
 	
 	requires com.google.common;

--- a/src/main/java/org/cryptomator/cloudaccess/CloudAccess.java
+++ b/src/main/java/org/cryptomator/cloudaccess/CloudAccess.java
@@ -1,0 +1,23 @@
+package org.cryptomator.cloudaccess;
+
+import java.nio.file.Path;
+
+import org.cryptomator.cloudaccess.api.CloudProvider;
+import org.cryptomator.cloudaccess.localfs.LocalFsCloudProvider;
+
+public class CloudAccess {
+
+	private CloudAccess() {
+	}
+
+	/**
+	 * Creates a new CloudProvider which provides access to the given <code>folder</code>. Mainly for test purposes.
+	 *
+	 * @param folder An existing folder on the (local) default file system.
+	 * @return A cloud access provider that provides access to the given local directory.
+	 */
+	static CloudProvider toLocalFileSystem(Path folder) {
+		return new LocalFsCloudProvider(folder);
+	}
+
+}

--- a/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
+++ b/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
@@ -3,6 +3,7 @@ package org.cryptomator.cloudaccess.localfs;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.file.CopyOption;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
@@ -14,11 +15,9 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -32,7 +31,7 @@ import org.cryptomator.cloudaccess.api.CloudProvider;
 import org.cryptomator.cloudaccess.api.ProgressListener;
 
 public class LocalFsCloudProvider implements CloudProvider {
-	
+
 	private static final Path ABS_ROOT = Path.of("/");
 
 	private final Path root;
@@ -40,12 +39,12 @@ public class LocalFsCloudProvider implements CloudProvider {
 	public LocalFsCloudProvider(Path root) {
 		this.root = root;
 	}
-	
+
 	private Path resolve(Path cloudPath) {
 		Path relPath = ABS_ROOT.relativize(cloudPath);
 		return root.resolve(relPath);
 	}
-	
+
 	private CloudItemMetadata createMetadata(Path fullPath, BasicFileAttributes attr) {
 		var relPath = root.relativize(fullPath);
 		var type = attr.isDirectory() ? CloudItemType.FOLDER : attr.isRegularFile() ? CloudItemType.FILE : CloudItemType.UNKNOWN;
@@ -53,7 +52,7 @@ public class LocalFsCloudProvider implements CloudProvider {
 		var size = Optional.of(attr.size());
 		return new CloudItemMetadata(relPath.getFileName().toString(), ABS_ROOT.resolve(relPath), type, modifiedDate, size);
 	}
-	
+
 	@Override
 	public CompletionStage<CloudItemMetadata> itemMetadata(Path node) {
 		Path path = resolve(node);
@@ -72,7 +71,7 @@ public class LocalFsCloudProvider implements CloudProvider {
 		try {
 			List<CloudItemMetadata> items = new ArrayList<>();
 			Files.walkFileTree(folderPath, EnumSet.noneOf(FileVisitOption.class), 1, new SimpleFileVisitor<>() {
-	
+
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
 					items.add(createMetadata(file, attrs));
@@ -99,7 +98,19 @@ public class LocalFsCloudProvider implements CloudProvider {
 
 	@Override
 	public CompletionStage<CloudItemMetadata> write(Path file, boolean replace, InputStream data, ProgressListener progressListener) {
-		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+		Path filePath = resolve(file);
+		var options = replace
+				? EnumSet.of(StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+				: EnumSet.of(StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW);
+
+		try (var ch = FileChannel.open(filePath, options)) {
+			var size = ch.transferFrom(Channels.newChannel(data), 0, Long.MAX_VALUE);
+			var modifiedDate = Files.getLastModifiedTime(filePath).toInstant();
+			var metadata = new CloudItemMetadata(file.getFileName().toString(), file, CloudItemType.FILE, Optional.of(modifiedDate), Optional.of(size));
+			return CompletableFuture.completedFuture(metadata);
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
+++ b/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
@@ -3,18 +3,22 @@ package org.cryptomator.cloudaccess.localfs;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
+import java.nio.file.CopyOption;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -122,6 +126,14 @@ public class LocalFsCloudProvider implements CloudProvider {
 
 	@Override
 	public CompletionStage<Path> move(Path source, Path target, boolean replace) {
-		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+		Path src = resolve(source);
+		Path dst = resolve(target);
+		try {
+			var options = replace ? EnumSet.of(StandardCopyOption.REPLACE_EXISTING) : EnumSet.noneOf(StandardCopyOption.class);
+			Files.move(src, dst, options.toArray(CopyOption[]::new));
+			return CompletableFuture.completedFuture(target);
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
 	}
 }

--- a/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
+++ b/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
@@ -2,9 +2,7 @@ package org.cryptomator.cloudaccess.localfs;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.ByteChannel;
 import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -100,7 +98,13 @@ public class LocalFsCloudProvider implements CloudProvider {
 
 	@Override
 	public CompletionStage<Path> createFolder(Path folder) {
-		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+		Path folderPath = resolve(folder);
+		try {
+			Files.createDirectory(folderPath);
+			return CompletableFuture.completedFuture(folder);
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
+++ b/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
@@ -19,6 +19,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import com.google.common.io.ByteStreams;
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import org.cryptomator.cloudaccess.api.CloudItemList;
 import org.cryptomator.cloudaccess.api.CloudItemMetadata;
 import org.cryptomator.cloudaccess.api.CloudItemType;
@@ -109,7 +111,13 @@ public class LocalFsCloudProvider implements CloudProvider {
 
 	@Override
 	public CompletionStage<Void> delete(Path node) {
-		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+		Path path = resolve(node);
+		try {
+			MoreFiles.deleteRecursively(path, RecursiveDeleteOption.ALLOW_INSECURE);
+			return CompletableFuture.completedFuture(null);
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
+++ b/src/main/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProvider.java
@@ -1,0 +1,115 @@
+package org.cryptomator.cloudaccess.localfs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import com.google.common.io.ByteStreams;
+import org.cryptomator.cloudaccess.api.CloudItemList;
+import org.cryptomator.cloudaccess.api.CloudItemMetadata;
+import org.cryptomator.cloudaccess.api.CloudItemType;
+import org.cryptomator.cloudaccess.api.CloudProvider;
+import org.cryptomator.cloudaccess.api.ProgressListener;
+
+public class LocalFsCloudProvider implements CloudProvider {
+	
+	private static final Path ABS_ROOT = Path.of("/");
+
+	private final Path root;
+
+	public LocalFsCloudProvider(Path root) {
+		this.root = root;
+	}
+	
+	private Path resolve(Path cloudPath) {
+		Path relPath = ABS_ROOT.relativize(cloudPath);
+		return root.resolve(relPath);
+	}
+	
+	private CloudItemMetadata createMetadata(Path fullPath, BasicFileAttributes attr) {
+		var relPath = root.relativize(fullPath);
+		var type = attr.isDirectory() ? CloudItemType.FOLDER : attr.isRegularFile() ? CloudItemType.FILE : CloudItemType.UNKNOWN;
+		var modifiedDate = Optional.of(attr.lastModifiedTime().toInstant());
+		var size = Optional.of(attr.size());
+		return new CloudItemMetadata(relPath.getFileName().toString(), ABS_ROOT.resolve(relPath), type, modifiedDate, size);
+	}
+	
+	@Override
+	public CompletionStage<CloudItemMetadata> itemMetadata(Path node) {
+		Path path = resolve(node);
+		try {
+			var attr = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+			var metadata = createMetadata(path, attr);
+			return CompletableFuture.completedFuture(metadata);
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
+	}
+
+	@Override
+	public CompletionStage<CloudItemList> list(Path folder, Optional<String> pageToken) {
+		Path folderPath = resolve(folder);
+		try {
+			List<CloudItemMetadata> items = new ArrayList<>();
+			Files.walkFileTree(folderPath, EnumSet.noneOf(FileVisitOption.class), 1, new SimpleFileVisitor<>() {
+	
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+					items.add(createMetadata(file, attrs));
+					return FileVisitResult.CONTINUE;
+				}
+			});
+			return CompletableFuture.completedFuture(new CloudItemList(items, Optional.empty()));
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
+	}
+
+	@Override
+	public CompletionStage<InputStream> read(Path file, long offset, long count, ProgressListener progressListener) {
+		Path filePath = resolve(file);
+		try {
+			var ch = Files.newByteChannel(filePath, StandardOpenOption.READ);
+			ch.position(offset);
+			return CompletableFuture.completedFuture(ByteStreams.limit(Channels.newInputStream(ch), count));
+		} catch (IOException e) {
+			return CompletableFuture.failedFuture(e);
+		}
+	}
+
+	@Override
+	public CompletionStage<CloudItemMetadata> write(Path file, boolean replace, InputStream data, ProgressListener progressListener) {
+		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+	}
+
+	@Override
+	public CompletionStage<Path> createFolder(Path folder) {
+		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+	}
+
+	@Override
+	public CompletionStage<Void> delete(Path node) {
+		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+	}
+
+	@Override
+	public CompletionStage<Path> move(Path source, Path target, boolean replace) {
+		return CompletableFuture.failedFuture(new UnsupportedOperationException("not implemented"));
+	}
+}

--- a/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
+++ b/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
@@ -78,4 +78,13 @@ public class LocalFsCloudProviderTest {
 			Assertions.assertArrayEquals("o w".getBytes(), allBytes);
 		}
 	}
+	
+	@Test
+	public void testCreateFolder() {
+		var result = provider.createFolder(Path.of("/folder"));
+		var folder = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get());
+		
+		Assertions.assertEquals(Path.of("/folder"), folder);
+		Assertions.assertTrue(Files.isDirectory(root.resolve("folder")));
+	}
 }

--- a/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
+++ b/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
@@ -1,0 +1,81 @@
+package org.cryptomator.cloudaccess.localfs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+import org.cryptomator.cloudaccess.api.CloudItemMetadata;
+import org.cryptomator.cloudaccess.api.CloudItemType;
+import org.cryptomator.cloudaccess.api.CloudProvider;
+import org.cryptomator.cloudaccess.api.ProgressListener;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class LocalFsCloudProviderTest {
+
+	private Path root;
+	private CloudProvider provider;
+
+	@BeforeEach
+	public void setup(@TempDir Path tempDir) {
+		this.root = tempDir;
+		this.provider = new LocalFsCloudProvider(tempDir);
+	}
+
+	@Test
+	public void testItemMetadata() throws IOException {
+		Files.write(root.resolve("file"), "hello world".getBytes());
+
+		var result = provider.itemMetadata(Path.of("/file"));
+		var metaData = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get());
+
+		Assertions.assertEquals("file", metaData.getName());
+		Assertions.assertEquals(Path.of("/file"), metaData.getPath());
+		Assertions.assertEquals(CloudItemType.FILE, metaData.getItemType());
+		Assertions.assertTrue(metaData.getSize().isPresent());
+		Assertions.assertEquals(11, metaData.getSize().get());
+		Assertions.assertTrue(metaData.getLastModifiedDate().isPresent());
+		Assertions.assertEquals(Files.getLastModifiedTime(root.resolve("file")).toInstant(), metaData.getLastModifiedDate().get());
+
+	}
+
+	@Test
+	public void testListExhaustively() throws IOException {
+		Files.createDirectory(root.resolve("dir"));
+		Files.createFile(root.resolve("file"));
+
+		var result = provider.listExhaustively(Path.of("/"));
+		var itemList = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get());
+		
+		Assertions.assertFalse(itemList.getNextPageToken().isPresent());
+		MatcherAssert.assertThat(itemList.getItems().stream().map(CloudItemMetadata::getPath).collect(Collectors.toSet()), CoreMatchers.hasItems(Path.of("/file"), Path.of("/dir")));
+	}
+
+	@Test
+	public void testRead() throws IOException {
+		Files.write(root.resolve("file"), "hello world".getBytes());
+
+		var result = provider.read(Path.of("/file"), ProgressListener.NO_PROGRESS_AWARE);
+		try (var in = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get())) {
+			var allBytes = in.readAllBytes();
+			Assertions.assertArrayEquals("hello world".getBytes(), allBytes);
+		}
+	}
+
+	@Test
+	public void testRandomAccessRead() throws IOException {
+		Files.write(root.resolve("file"), "hello world".getBytes());
+
+		var result = provider.read(Path.of("/file"), 4, 3, ProgressListener.NO_PROGRESS_AWARE);
+		try (var in = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get())) {
+			var allBytes = in.readAllBytes();
+			Assertions.assertArrayEquals("o w".getBytes(), allBytes);
+		}
+	}
+}

--- a/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
+++ b/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
@@ -89,9 +89,8 @@ public class LocalFsCloudProviderTest {
 	@Test
 	@DisplayName("write to /file (non-existing)")
 	public void testWriteToNewFile() throws IOException {
-		//Files.write(root.resolve("file"), "hello world".getBytes());
-
 		var in = new ByteArrayInputStream("hallo welt".getBytes());
+		
 		var result = provider.write(Path.of("/file"), false, in, ProgressListener.NO_PROGRESS_AWARE);
 		var metaData = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () -> result.toCompletableFuture().get());
 
@@ -108,8 +107,8 @@ public class LocalFsCloudProviderTest {
 	@DisplayName("write to /file (already existing)")
 	public void testWriteToExistingFile() throws IOException {
 		Files.write(root.resolve("file"), "hello world".getBytes());
-
 		var in = new ByteArrayInputStream("hallo welt".getBytes());
+		
 		var result = provider.write(Path.of("/file"), false, in, ProgressListener.NO_PROGRESS_AWARE);
 
 		var thrown = Assertions.assertThrows(ExecutionException.class, () -> {
@@ -123,8 +122,8 @@ public class LocalFsCloudProviderTest {
 	@DisplayName("write to /file (replace existing)")
 	public void testWriteToAndReplaceExistingFile() throws IOException {
 		Files.write(root.resolve("file"), "hello world".getBytes());
-
 		var in = new ByteArrayInputStream("hallo welt".getBytes());
+		
 		var result = provider.write(Path.of("/file"), true, in, ProgressListener.NO_PROGRESS_AWARE);
 		var metaData = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () -> result.toCompletableFuture().get());
 

--- a/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
+++ b/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
@@ -1,9 +1,11 @@
 package org.cryptomator.cloudaccess.localfs;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.cryptomator.cloudaccess.api.CloudItemMetadata;
@@ -14,6 +16,7 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -29,6 +32,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("get metadata of /file")
 	public void testItemMetadata() throws IOException {
 		Files.write(root.resolve("file"), "hello world".getBytes());
 
@@ -46,6 +50,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("list /")
 	public void testListExhaustively() throws IOException {
 		Files.createDirectory(root.resolve("dir"));
 		Files.createFile(root.resolve("file"));
@@ -58,6 +63,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("read /file (complete)")
 	public void testRead() throws IOException {
 		Files.write(root.resolve("file"), "hello world".getBytes());
 
@@ -69,6 +75,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("read /file (bytes 4-6)")
 	public void testRandomAccessRead() throws IOException {
 		Files.write(root.resolve("file"), "hello world".getBytes());
 
@@ -80,6 +87,7 @@ public class LocalFsCloudProviderTest {
 	}
 	
 	@Test
+	@DisplayName("create /folder")
 	public void testCreateFolder() {
 		var result = provider.createFolder(Path.of("/folder"));
 		var folder = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get());
@@ -89,6 +97,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("delete /file")
 	public void testDeleteFile() throws IOException {
 		Files.createFile(root.resolve("file"));
 		
@@ -99,6 +108,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("delete /folder (recursively)")
 	public void testDeleteFolder() throws IOException {
 		Files.createDirectory(root.resolve("folder"));
 		Files.createFile(root.resolve("folder/file"));
@@ -110,6 +120,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("move /foo -> /bar")
 	public void testMoveToNonExisting() throws IOException {
 		Files.createFile(root.resolve("foo"));
 
@@ -122,6 +133,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("move /foo -> /bar (which already exists)")
 	public void testMoveToExisting() throws IOException {
 		Files.createFile(root.resolve("foo"));
 		Files.createFile(root.resolve("bar"));
@@ -135,6 +147,7 @@ public class LocalFsCloudProviderTest {
 	}
 
 	@Test
+	@DisplayName("move /foo -> /bar (replace existing)")
 	public void testMoveToAndReplaceExisting() throws IOException {
 		Files.createFile(root.resolve("foo"));
 		Files.createFile(root.resolve("bar"));

--- a/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
+++ b/src/test/java/org/cryptomator/cloudaccess/localfs/LocalFsCloudProviderTest.java
@@ -87,4 +87,25 @@ public class LocalFsCloudProviderTest {
 		Assertions.assertEquals(Path.of("/folder"), folder);
 		Assertions.assertTrue(Files.isDirectory(root.resolve("folder")));
 	}
+
+	@Test
+	public void testDeleteFile() throws IOException {
+		Files.createFile(root.resolve("file"));
+		
+		var result = provider.delete(Path.of("/file"));
+		Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get());
+
+		Assertions.assertTrue(Files.notExists(root.resolve("file")));
+	}
+
+	@Test
+	public void testDeleteFolder() throws IOException {
+		Files.createDirectory(root.resolve("folder"));
+		Files.createFile(root.resolve("folder/file"));
+
+		var result = provider.delete(Path.of("/folder"));
+		Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () ->  result.toCompletableFuture().get());
+
+		Assertions.assertTrue(Files.notExists(root.resolve("folder")));
+	}
 }


### PR DESCRIPTION
Added `LocalFsCloudProvider` which can be used for testing against the CloudProvider API on downstream dependencies.

Note that the unit test doesn't cover all cases yet, such as `NoSuchFileExceptions` when reading from non-existing files.